### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Magnus Kvendseth Øye
 maintainer=Magnus Kvendseth Øye
 sentence=Kalman Filter
 paragraph=Signal Processing
-category=Uncategorised
+category=Data Processing
 url=https://github.com/magnusoy/Arduino-KalmanFilter-Library
 architectures=* 


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Uncategorised' in library KalmanFilter is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format