### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,11 +14,11 @@ KalmanFilter	KEYWORD1
 
 in	KEYWORD2
 out	KEYWORD2
-setInputError  KEYWORD2
-setEstimateError  KEYWORD2
-setProcessNoise  KEYWORD2
-getKalmanGain  KEYWORD2
-getEstimateError  KEYWORD2
+setInputError	KEYWORD2
+setEstimateError	KEYWORD2
+setProcessNoise	KEYWORD2
+getKalmanGain	KEYWORD2
+getEstimateError	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords